### PR TITLE
Implement missing DAppSigner methods for Signer interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,22 @@ reference the [WalletConnect documentation](https://docs.walletconnect.com/2.0/)
 Upon successfully configuring your dApp and/or wallet to manage WalletConnect sessions, you can
 use this library’s functions to easily create and handle requests for the Hedera network.
 
+### DApps
+
+#### Signer
+
+This library provides a `DAppSigner` class that implements the `@hashgraph/sdk`'s `Signer` interface. You may use the `DAppSigner` class to sign and execute transactions on the Hedera network.
+
+```javascript
+const transaction = new TransferTransaction()
+  .addHbarTransfer('0.0.100', new Hbar(-1))
+  .addHbarTransfer('0.0.101', new Hbar(1))
+
+const signer = dAppConnector.signers[0] // DAppSigner
+await transaction.freezeWithSigner(signer)
+const transactionResponse = await transaction.executeWithSigner(signer)
+```
+
 ### Wallet
 
 This library provides a Wallet class that extends the

--- a/README.md
+++ b/README.md
@@ -69,16 +69,59 @@ use this library’s functions to easily create and handle requests for the Hede
 
 #### Signer
 
-This library provides a `DAppSigner` class that implements the `@hashgraph/sdk`'s `Signer` interface. You may use the `DAppSigner` class to sign and execute transactions on the Hedera network.
+This library provides a `DAppSigner` class that implements the `@hashgraph/sdk`'s `Signer`
+interface. You may use the `DAppSigner` class to sign and execute transactions on the Hedera
+network.
+
+##### Get Signer
+
+After you have paired your wallet with your dApp, you can get the signer from the
+`DAppConnector` instance:
+
+```javascript
+const signer = dAppConnector.signers[0] // DAppSigner
+```
+
+Or, if multiple signers are available, you can find the signer by account ID:
+
+```javascript
+const signer = dAppConnector.signers.find(
+  (signer_) => signer_.getAccountId.toString() === '0.0.100',
+) // DAppSigner
+```
+
+##### Sign Transactions
 
 ```javascript
 const transaction = new TransferTransaction()
   .addHbarTransfer('0.0.100', new Hbar(-1))
   .addHbarTransfer('0.0.101', new Hbar(1))
 
-const signer = dAppConnector.signers[0] // DAppSigner
+await transaction.freezeWithSigner(signer)
+const signedTransaction = await signer.signTransaction(transaction)
+```
+
+##### Sign and Execute Transactions
+
+```javascript
+const transaction = new TransferTransaction()
+  .addHbarTransfer('0.0.100', new Hbar(-1))
+  .addHbarTransfer('0.0.101', new Hbar(1))
+
 await transaction.freezeWithSigner(signer)
 const transactionResponse = await transaction.executeWithSigner(signer)
+```
+
+##### Sign and verify messages
+
+```javascript
+const text = 'Example message to sign'
+const base64String = btoa(text)
+
+const sigMaps = await signer.sign([base64StringToUint8Array(base64String)]) // import { base64StringToUint8Array } from '@hashgraph/hedera-wallet-connect'
+
+// sigMaps[0].publicKey also contains the public key of the signer, but you should obtain a PublicKey you can trust from a mirror node.
+const verifiedResult = verifySignerSignature(base64String, sigMaps[0], publicKey) // import { verifySignerSignature } from '@hashgraph/hedera-wallet-connect'
 ```
 
 ### Wallet

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Or, if multiple signers are available, you can find the signer by account ID:
 
 ```javascript
 const signer = dAppConnector.signers.find(
-  (signer_) => signer_.getAccountId.toString() === '0.0.100',
+  (signer_) => signer_.getAccountId().toString() === '0.0.100',
 ) // DAppSigner
 ```
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "dev": "rimraf dist && npm run build && concurrently --raw \"npm run watch\" \"node scripts/examples/dev.mjs\"",
     "test": "jest",
     "test:connect": "jest --testMatch '**/DAppConnector.test.ts' --verbose",
+    "test:signer": "jest --testMatch '**/DAppSigner.test.ts' --verbose",
     "prepublishOnly": "rm -Rf dist && npm run build",
     "prepare": "husky install",
     "prettier:check": "prettier --check ./src/",

--- a/src/examples/typescript/dapp/index.html
+++ b/src/examples/typescript/dapp/index.html
@@ -189,6 +189,112 @@
       </section>
 
       <hr />
+      <h2>Hedera &lt;&gt; WalletConnect - Signer methods:</h2>
+
+      <section>
+        <form id="signer_signAndExecuteTransaction" class="toggle">
+          <fieldset>
+            <legend>transaction.executeWithSigner(signer)</legend>
+            <label
+              >Transaction type:
+              <select name="sign-send-transaction-type">
+                <option value="hbar-transfer">Hbar Transfer</option>
+              </select>
+            </label>
+            <label
+              >Send to address:
+              <input name="sign-send-to" required />
+            </label>
+            <label
+              >Send from address:
+              <input name="sign-send-from" required />
+            </label>
+            <label
+              >Amount in Hbar:
+              <input name="sign-send-amount" required />
+            </label>
+          </fieldset>
+          <button type="submit">Submit to wallet</button>
+        </form>
+      </section>
+
+      <section>
+        <form id="signer_signTransaction" class="toggle">
+          <fieldset>
+            <legend>signer.signTransaction(transaction)</legend>
+            <label
+              >Transaction type:
+              <select name="sign-send-transaction-type">
+                <option value="hbar-transfer">Hbar Transfer</option>
+              </select>
+            </label>
+            <label
+              >Send to address:
+              <input name="sign-send-to" required />
+            </label>
+            <label
+              >Send from address:
+              <input name="sign-send-from" required />
+            </label>
+            <label
+              >Amount in Hbar:
+              <input name="sign-send-amount" required />
+            </label>
+          </fieldset>
+          <button type="submit">Submit to wallet</button>
+        </form>
+      </section>
+
+      <section>
+        <form id="signer_sign" class="toggle">
+          <fieldset>
+            <legend>signer.sign(bytesArray)</legend>
+            <p>
+              Uses the signer sign an array of bytes. Although currently, only the first element
+              will be signed and returned.
+            </p>
+            <label
+              >Sign text:
+              <input name="sign-text" required />
+            </label>
+          </fieldset>
+          <button type="submit">Submit to wallet</button>
+        </form>
+      </section>
+
+      <section>
+        <form id="signer_getAccountBalance" class="toggle">
+          <fieldset>
+            <legend>signer.getAccountBalance()</legend>
+            <p>
+              <i>Uses the signer to call AccountBalanceQuery</i>
+            </p>
+          </fieldset>
+          <button type="submit">Submit to wallet</button>
+        </form>
+      </section>
+
+      <section>
+        <form id="signer_getAccountInfo" class="toggle">
+          <fieldset>
+            <legend>signer.getAccountInfo()</legend>
+            <p>Uses the signer to call AccountInfoQuery</p>
+          </fieldset>
+          <button type="submit">Submit to wallet</button>
+        </form>
+      </section>
+
+      <section>
+        <form id="signer_getAccountRecords" class="toggle">
+          <fieldset>
+            <legend>signer.getAccountRecords()</legend>
+            <p>Uses the signer to call AccountRecordsQuery</p>
+          </fieldset>
+          <button type="submit">Submit to wallet</button>
+        </form>
+      </section>
+
+      <hr />
       <h2>Error handling:</h2>
       <section class="toggle">
         <fieldset>

--- a/src/examples/typescript/dapp/main.ts
+++ b/src/examples/typescript/dapp/main.ts
@@ -41,6 +41,7 @@ import {
   transactionToTransactionBody,
   transactionBodyToBase64String,
   base64StringToSignatureMap,
+  base64StringToUint8Array,
   queryToBase64String,
   ExecuteTransactionParams,
   SignMessageParams,
@@ -50,6 +51,7 @@ import {
   DAppConnector,
   HederaChainId,
   verifyMessageSignature,
+  verifySignerSignature,
 } from '@hashgraph/hedera-wallet-connect'
 
 import { saveState, loadState, getState } from '../shared'
@@ -338,3 +340,59 @@ async function simulateTransactionExpiredError(_: Event) {
 
 document.getElementById('error-transaction-expired')!.onsubmit = (e: SubmitEvent) =>
   showErrorOrSuccess(simulateTransactionExpiredError, e)
+
+async function signer_signAndExecuteTransaction(_: Event) {
+  const transaction = new TransferTransaction()
+    .addHbarTransfer(getState('sign-send-from'), new Hbar(-getState('sign-send-amount')))
+    .addHbarTransfer(getState('sign-send-to'), new Hbar(+getState('sign-send-amount')))
+
+  const signer = dAppConnector!.signers[0]
+  await transaction.freezeWithSigner(signer)
+  return await transaction.executeWithSigner(signer)
+}
+document.getElementById('signer_signAndExecuteTransaction')!.onsubmit = (e: SubmitEvent) =>
+  showErrorOrSuccess(signer_signAndExecuteTransaction, e)
+
+async function signer_signTransaction(_: Event) {
+  const transaction = new TransferTransaction()
+    .addHbarTransfer(getState('sign-send-from'), new Hbar(-getState('sign-send-amount')))
+    .addHbarTransfer(getState('sign-send-to'), new Hbar(+getState('sign-send-amount')))
+
+  const signer = dAppConnector!.signers[0]
+  await transaction.freezeWithSigner(signer)
+  return await signer.signTransaction(transaction)
+}
+document.getElementById('signer_signTransaction')!.onsubmit = (e: SubmitEvent) =>
+  showErrorOrSuccess(signer_signTransaction, e)
+
+async function signer_sign(_: Event) {
+  const text = getState('sign-text')
+  const base64String = btoa(text)
+  const signer = dAppConnector!.signers[0]
+  const sigMaps = await signer.sign([base64StringToUint8Array(base64String)])
+  const verifiedResult = verifySignerSignature(base64String, sigMaps[0], sigMaps[0].publicKey)
+  return { verifiedResult, sigMaps }
+}
+document.getElementById('signer_sign')!.onsubmit = (e: SubmitEvent) =>
+  showErrorOrSuccess(signer_sign, e)
+
+async function signer_getAccountBalance(_: Event) {
+  const signer = dAppConnector!.signers[0]
+  return await signer.getAccountBalance()
+}
+document.getElementById('signer_getAccountBalance')!.onsubmit = (e: SubmitEvent) =>
+  showErrorOrSuccess(signer_getAccountBalance, e)
+
+async function signer_getAccountInfo(_: Event) {
+  const signer = dAppConnector!.signers[0]
+  return await signer.getAccountInfo()
+}
+document.getElementById('signer_getAccountInfo')!.onsubmit = (e: SubmitEvent) =>
+  showErrorOrSuccess(signer_getAccountInfo, e)
+
+async function signer_getAccountRecords(_: Event) {
+  const signer = dAppConnector!.signers[0]
+  return await signer.getAccountRecords()
+}
+document.getElementById('signer_getAccountRecords')!.onsubmit = (e: SubmitEvent) =>
+  showErrorOrSuccess(signer_getAccountRecords, e)

--- a/src/examples/typescript/index.html
+++ b/src/examples/typescript/index.html
@@ -62,8 +62,8 @@
   <body>
     <main>
       <!-- need to be on different host / port combinations https://github.com/WalletConnect/walletconnect-monorepo/issues/2975 -->
-      <iframe src=""></iframe>
-      <iframe src=""></iframe>
+      <iframe src="" allow="clipboard-write"></iframe>
+      <iframe src="" allow="clipboard-write"></iframe>
       <div class="overlay">
         <div class="active"></div>
         <div></div>

--- a/src/lib/dapp/DAppSigner.ts
+++ b/src/lib/dapp/DAppSigner.ts
@@ -136,7 +136,7 @@ export class DAppSigner implements Signer {
     data: Uint8Array[],
     signOptions?: Record<string, any>,
   ): Promise<SignerSignature[]> {
-    const response = await this.request<SignTransactionResult>({
+    const { signatureMap } = await this.request<SignTransactionResult['result']>({
       method: HederaJsonRpcMethod.SignMessage,
       params: {
         signerAccountId: this._signerAccountId,
@@ -144,7 +144,7 @@ export class DAppSigner implements Signer {
       },
     })
 
-    const sigmap = base64StringToSignatureMap(response.result.signatureMap)
+    const sigmap = base64StringToSignatureMap(signatureMap)
 
     const signerSignature = new SignerSignature({
       accountId: this.getAccountId(),
@@ -174,7 +174,7 @@ export class DAppSigner implements Signer {
     )
     const transactionBodyBase64 = transactionBodyToBase64String(transactionBody)
 
-    const { result } = await this.request<SignTransactionResult>({
+    const { signatureMap } = await this.request<SignTransactionResult['result']>({
       method: HederaJsonRpcMethod.SignTransaction,
       params: {
         signerAccountId: this._signerAccountId,
@@ -182,7 +182,7 @@ export class DAppSigner implements Signer {
       },
     })
 
-    const sigMap = base64StringToSignatureMap(result.signatureMap)
+    const sigMap = base64StringToSignatureMap(signatureMap)
     const bodyBytes = Buffer.from(transactionBody, 'base64')
     const bytes = proto.Transaction.encode({ bodyBytes, sigMap }).finish()
     return Transaction.fromBytes(bytes) as T
@@ -196,7 +196,7 @@ export class DAppSigner implements Signer {
   }> {
     try {
       const transaction = Transaction.fromBytes(request.toBytes())
-      const { result } = await this.request<SignAndExecuteTransactionResult>({
+      const result = await this.request<SignAndExecuteTransactionResult['result']>({
         method: HederaJsonRpcMethod.SignAndExecuteTransaction,
         params: {
           signerAccountId: this._signerAccountId,
@@ -235,7 +235,7 @@ export class DAppSigner implements Signer {
     try {
       const query = Query.fromBytes(request.toBytes())
 
-      const { result } = await this.request<SignAndExecuteQueryResult>({
+      const result = await this.request<SignAndExecuteQueryResult['result']>({
         method: HederaJsonRpcMethod.SignAndExecuteQuery,
         params: {
           signerAccountId: this._signerAccountId,

--- a/src/lib/dapp/DAppSigner.ts
+++ b/src/lib/dapp/DAppSigner.ts
@@ -37,6 +37,8 @@ import {
   AccountRecordsQuery,
   AccountInfoQuery,
   AccountBalanceQuery,
+  TransactionReceiptQuery,
+  TransactionReceipt,
 } from '@hashgraph/sdk'
 import { proto } from '@hashgraph/proto'
 import type { ISignClient } from '@walletconnect/types'
@@ -226,6 +228,8 @@ export class DAppSigner implements Signer {
       return AccountBalance.fromBytes(data)
     } else if (query instanceof AccountInfoQuery) {
       return AccountInfo.fromBytes(data)
+    } else if (query instanceof TransactionReceiptQuery) {
+      return TransactionReceipt.fromBytes(data)
     } else {
       throw new Error('Unsupported query type')
     }

--- a/src/lib/shared/utils.ts
+++ b/src/lib/shared/utils.ts
@@ -229,6 +229,7 @@ export function stringToSignerMessage(message: string): Uint8Array[] {
  *
  * @param message -  A plain text string
  * @param base64SignatureMap -  A base64 encoded proto.SignatureMap object
+ * @param publicKey -  A PublicKey object use to verify the signature
  * @returns boolean - whether or not the first signature in the sigPair is valid for the message and public key
  */
 export function verifyMessageSignature(
@@ -238,6 +239,28 @@ export function verifyMessageSignature(
 ): boolean {
   const signatureMap = base64StringToSignatureMap(base64SignatureMap)
   const signature = signatureMap.sigPair[0].ed25519 || signatureMap.sigPair[0].ECDSASecp256k1
+
+  if (!signature) throw new Error('Signature not found in signature map')
+
+  return publicKey.verify(Buffer.from(prefixMessageToSign(message)), signature)
+}
+
+/**
+ * This implementation expects a plain text string, which is prefixed and then signed by a wallet.
+ * Because the spec calls for 1 message to be signed and 1 signer, this function expects a single
+ * signature and used the first item in the sigPair array.
+ *
+ * @param message -  A plain text string
+ * @param signerSignature -  A SignerSignature object
+ * @param publicKey -  A PublicKey object use to verify the signature
+ * @returns boolean - whether or not the first signature in the sigPair is valid for the message and public key
+ */
+export function verifySignerSignature(
+  message: string,
+  signerSignature: SignerSignature,
+  publicKey: PublicKey,
+): boolean {
+  const signature = signerSignature.signature
 
   if (!signature) throw new Error('Signature not found in signature map')
 

--- a/src/lib/wallet/index.ts
+++ b/src/lib/wallet/index.ts
@@ -355,8 +355,13 @@ export class HederaWeb3Wallet extends Web3Wallet implements HederaNativeWallet {
      * For example:
      * https://github.com/hashgraph/hedera-sdk-js/blob/c4438cbaa38074d8bfc934dba84e3b430344ed89/src/account/AccountInfo.js#L402
      */
-    const queryResult = (await body.executeWithSigner(signer)) as { toBytes: () => Uint8Array }
-    const queryResponse = Uint8ArrayToBase64String(queryResult.toBytes())
+    const queryResult = await body.executeWithSigner(signer)
+    let queryResponse = ''
+    if (Array.isArray(queryResult)) {
+      queryResponse = queryResult.map((qr) => Uint8ArrayToBase64String(qr.toBytes())).join(',')
+    } else {
+      queryResponse = Uint8ArrayToBase64String(queryResult.toBytes())
+    }
 
     const response: SignAndExecuteQueryResponse = {
       topic,

--- a/test/_helpers.ts
+++ b/test/_helpers.ts
@@ -20,7 +20,7 @@
 
 import fs from 'fs'
 import path from 'path'
-import { AccountId, Transaction, TransactionId } from '@hashgraph/sdk'
+import { AccountId, Query, Transaction, TransactionId } from '@hashgraph/sdk'
 
 export const projectId = 'ce06497abf4102004138a10edd29c921'
 export const walletMetadata = {
@@ -50,7 +50,7 @@ export const testTransactionId = TransactionId.fromString(
   `0.0.${defaultAccountNumber}@1691705630.325343432`,
 )
 
-type Options = {
+type TransactionOptions = {
   setNodeAccountIds?: boolean
   setTransactionId?: boolean
   freeze?: boolean
@@ -58,9 +58,9 @@ type Options = {
 }
 export function prepareTestTransaction<T extends Transaction = Transaction>(
   transaction: T,
-  options?: Options,
+  options?: TransactionOptions,
 ): T {
-  const selectedOptions: Options = {
+  const selectedOptions: TransactionOptions = {
     // defaults
     freeze: false,
     setNodeAccountIds: true,
@@ -86,6 +86,25 @@ export function prepareTestTransaction<T extends Transaction = Transaction>(
     transaction.freeze()
   }
   return transaction
+}
+
+type QueryOptions = {
+  setNodeAccountIds?: boolean
+}
+export function prepareTestQuery<Q extends Query<OutputT>, OutputT>(
+  query: Q,
+  options?: QueryOptions,
+): Q {
+  const selectedOptions: QueryOptions = {
+    // defaults
+    setNodeAccountIds: true,
+    // overrides
+    ...options,
+  }
+  if (selectedOptions.setNodeAccountIds) {
+    query.setNodeAccountIds([testNodeAccountId])
+  }
+  return query
 }
 
 // from PrivateKey.generateECDSA().toStringDer()

--- a/test/dapp/DAppSigner.test.ts
+++ b/test/dapp/DAppSigner.test.ts
@@ -83,25 +83,17 @@ describe('DAppSigner', () => {
       signerRequestSpy.mockImplementation((request: { method: string; params: any }) => {
         const { method } = request
         if (method === HederaJsonRpcMethod.SignAndExecuteTransaction) {
-          const response: SignAndExecuteTransactionResult = {
-            id: 1,
-            jsonrpc: '2.0',
-            result: {
-              transactionId: TransactionId.generate('0.0.999').toString(),
-              nodeId: '0.0.3',
-              transactionHash: '0x',
-            },
+          const response: SignAndExecuteTransactionResult['result'] = {
+            transactionId: TransactionId.generate('0.0.999').toString(),
+            nodeId: '0.0.3',
+            transactionHash: '0x',
           }
           return Promise.resolve(response)
         } else if (method === HederaJsonRpcMethod.ExecuteTransaction) {
-          const response: ExecuteTransactionResult = {
-            id: 1,
-            jsonrpc: '2.0',
-            result: {
-              transactionId: TransactionId.generate('0.0.999').toString(),
-              nodeId: '0.0.3',
-              transactionHash: '0x',
-            },
+          const response: ExecuteTransactionResult['result'] = {
+            transactionId: TransactionId.generate('0.0.999').toString(),
+            nodeId: '0.0.3',
+            transactionHash: '0x',
           }
           return Promise.resolve(response)
         } else if (method === HederaJsonRpcMethod.SignAndExecuteQuery) {
@@ -135,12 +127,8 @@ describe('DAppSigner', () => {
               }).finish(),
             )
           }
-          const response: SignAndExecuteQueryResult = {
-            id: 1,
-            jsonrpc: '2.0',
-            result: {
-              response: queryResponse,
-            },
+          const response: SignAndExecuteQueryResult['result'] = {
+            response: queryResponse,
           }
           return Promise.resolve(response)
         }

--- a/test/dapp/DAppSigner.test.ts
+++ b/test/dapp/DAppSigner.test.ts
@@ -21,10 +21,12 @@
 import {
   AccountBalanceQuery,
   AccountCreateTransaction,
+  AccountId,
   AccountInfoQuery,
   AccountRecordsQuery,
   AccountUpdateTransaction,
   LedgerId,
+  PrivateKey,
   TokenAssociateTransaction,
   TokenCreateTransaction,
   TopicCreateTransaction,
@@ -107,23 +109,45 @@ describe('DAppSigner', () => {
             )
           } else if (query instanceof AccountInfoQuery) {
             queryResponse = Uint8ArrayToBase64String(
-              proto.CryptoGetInfoQuery.encode({
+              proto.CryptoGetInfoResponse.AccountInfo.encode({
                 accountID: {
                   shardNum: 0,
                   realmNum: 0,
                   accountNum: 3,
                 },
+                contractAccountID: AccountId.fromString('0.0.3').toSolidityAddress(),
+                key: {
+                  ed25519: PrivateKey.generate().publicKey.toBytes(),
+                },
+                expirationTime: { seconds: 0, nanos: 0 },
               }).finish(),
             )
           } else if (query instanceof AccountRecordsQuery) {
             queryResponse = Uint8ArrayToBase64String(
-              proto.CryptoGetAccountRecordsResponse.encode({
-                accountID: {
-                  shardNum: 0,
-                  realmNum: 0,
-                  accountNum: 3,
+              proto.TransactionGetRecordResponse.encode({
+                transactionRecord: {
+                  alias: proto.Key.encode(
+                    PrivateKey.generate().publicKey._toProtobufKey(),
+                  ).finish(),
+                  receipt: {
+                    status: proto.ResponseCodeEnum.OK,
+                    accountID: {
+                      shardNum: 0,
+                      realmNum: 0,
+                      accountNum: 3,
+                    },
+                  },
+                  consensusTimestamp: { seconds: 0, nanos: 0 },
+                  transactionID: {
+                    accountID: {
+                      shardNum: 0,
+                      realmNum: 0,
+                      accountNum: 3,
+                    },
+                    transactionValidStart: { seconds: 0, nanos: 0 },
+                    nonce: 0,
+                  },
                 },
-                records: [],
               }).finish(),
             )
           }

--- a/test/dapp/DAppSigner.test.ts
+++ b/test/dapp/DAppSigner.test.ts
@@ -1,0 +1,164 @@
+/*
+ *
+ * Hedera Wallet Connect
+ *
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {
+  AccountBalanceQuery,
+  AccountCreateTransaction,
+  AccountUpdateTransaction,
+  FileContentsQuery,
+  LedgerId,
+  TokenAssociateTransaction,
+  TokenCreateTransaction,
+  TopicCreateTransaction,
+  TransactionId,
+} from '@hashgraph/sdk'
+import {
+  DAppConnector,
+  HederaJsonRpcMethod,
+  SignAndExecuteTransactionParams,
+  transactionToBase64String,
+  DAppSigner,
+  SignAndExecuteTransactionResult,
+  ExecuteTransactionResult,
+  SignAndExecuteQueryResult,
+  SignAndExecuteQueryParams,
+  Uint8ArrayToBase64String,
+} from '../../src'
+import {
+  projectId,
+  dAppMetadata,
+  useJsonFixture,
+  prepareTestTransaction,
+  prepareTestQuery,
+} from '../_helpers'
+import { SessionTypes } from '@walletconnect/types'
+
+describe('DAppSigner', () => {
+  let connector: DAppConnector
+  const fakeSession = useJsonFixture('fakeSession') as SessionTypes.Struct
+
+  beforeEach(() => {
+    connector = new DAppConnector(dAppMetadata, LedgerId.TESTNET, projectId)
+  })
+
+  afterEach(() => {
+    global.gc && global.gc()
+  })
+
+  describe(DAppSigner.prototype.call, () => {
+    let signerRequestSpy: jest.SpyInstance
+    let signer: DAppSigner
+
+    beforeEach(async () => {
+      const checkPersistedStateSpy = jest.spyOn(connector as any, 'checkPersistedState')
+      checkPersistedStateSpy.mockReturnValue([fakeSession])
+
+      await connector.init({ logger: 'error' })
+
+      checkPersistedStateSpy.mockRestore()
+
+      signer = connector.signers[0]
+
+      signerRequestSpy = jest.spyOn(connector.signers[0], 'request')
+      signerRequestSpy.mockImplementation((request: { method: string; params: any }) => {
+        const { method } = request
+        if (method === HederaJsonRpcMethod.SignAndExecuteTransaction) {
+          const response: SignAndExecuteTransactionResult = {
+            id: 1,
+            jsonrpc: '2.0',
+            result: {
+              transactionId: TransactionId.generate('0.0.999').toString(),
+              nodeId: '0.0.3',
+              transactionHash: '0x',
+            },
+          }
+          return Promise.resolve(response)
+        } else if (method === HederaJsonRpcMethod.ExecuteTransaction) {
+          const response: ExecuteTransactionResult = {
+            id: 1,
+            jsonrpc: '2.0',
+            result: {
+              transactionId: TransactionId.generate('0.0.999').toString(),
+              nodeId: '0.0.3',
+              transactionHash: '0x',
+            },
+          }
+          return Promise.resolve(response)
+        } else if (method === HederaJsonRpcMethod.SignAndExecuteQuery) {
+          const response: SignAndExecuteQueryResult = {
+            id: 1,
+            jsonrpc: '2.0',
+            result: {
+              response: 'TODO: Implement a real response here',
+            },
+          }
+          return Promise.resolve(response)
+        }
+      })
+    })
+
+    afterEach(() => {
+      signerRequestSpy.mockRestore()
+    })
+
+    it.each([
+      { name: AccountCreateTransaction.name, ExecutableType: AccountCreateTransaction },
+      { name: AccountUpdateTransaction.name, ExecutableType: AccountUpdateTransaction },
+      { name: TopicCreateTransaction.name, ExecutableType: TopicCreateTransaction },
+      { name: TokenAssociateTransaction.name, ExecutableType: TokenAssociateTransaction },
+      { name: TokenCreateTransaction.name, ExecutableType: TokenCreateTransaction },
+    ])('can execute $name transaction', async ({ name, ExecutableType }) => {
+      const transaction = prepareTestTransaction(new ExecutableType(), { freeze: true })
+
+      const params: SignAndExecuteTransactionParams = {
+        signerAccountId: 'hedera:testnet:' + signer.getAccountId().toString(),
+        transactionList: transactionToBase64String(transaction),
+      }
+      await signer.call(transaction)
+
+      expect(signerRequestSpy).toHaveBeenCalled()
+      expect(signerRequestSpy).toHaveBeenCalledTimes(1)
+      expect(signerRequestSpy).toHaveBeenCalledWith({
+        method: HederaJsonRpcMethod.SignAndExecuteTransaction,
+        params,
+      })
+    })
+
+    it.each([
+      { name: AccountBalanceQuery.name, ExecutableType: AccountBalanceQuery },
+      { name: FileContentsQuery.name, ExecutableType: FileContentsQuery },
+    ])('can execute $name query', async ({ name, ExecutableType }) => {
+      const query = prepareTestQuery<any, any>(new ExecutableType())
+
+      const params: SignAndExecuteQueryParams = {
+        signerAccountId: 'hedera:testnet:' + signer.getAccountId().toString(),
+        query: Uint8ArrayToBase64String(query.toBytes()),
+      }
+      await signer.call(query)
+
+      expect(signerRequestSpy).toHaveBeenCalled()
+      expect(signerRequestSpy).toHaveBeenCalledTimes(1)
+      expect(signerRequestSpy).toHaveBeenCalledWith({
+        method: HederaJsonRpcMethod.SignAndExecuteQuery,
+        params,
+      })
+    })
+  })
+})

--- a/test/dapp/DAppSigner.test.ts
+++ b/test/dapp/DAppSigner.test.ts
@@ -72,16 +72,11 @@ describe('DAppSigner', () => {
     let signer: DAppSigner
 
     beforeEach(async () => {
-      const checkPersistedStateSpy = jest.spyOn(connector as any, 'checkPersistedState')
-      checkPersistedStateSpy.mockReturnValue([fakeSession])
-
-      await connector.init({ logger: 'error' })
-
-      checkPersistedStateSpy.mockRestore()
-
+      // @ts-ignore
+      connector.signers = connector.createSigners(fakeSession)
       signer = connector.signers[0]
 
-      signerRequestSpy = jest.spyOn(connector.signers[0], 'request')
+      signerRequestSpy = jest.spyOn(signer, 'request')
       signerRequestSpy.mockImplementation((request: { method: string; params: any }) => {
         const { method } = request
         if (method === HederaJsonRpcMethod.SignAndExecuteTransaction) {


### PR DESCRIPTION
**Description**:

This PR implements missing Signer interface methods and supports the `transaction.executeWithSigner(signer)` flow.

I also added tests, updated the readme, and added examples to the example dapp.

I tested each of the methods in the example dapp.

Because of how the devDependencies in the `package.json` are currently setup, if you want to test the new functions, you will need to set the replace the `@hashgraph/hedera-wallet-connect` version dependency with `"."` instead of `"^1.0.5"`. That way the example dapp will use the current changes in this branch.

Methods implemented:
- call
- sign
- populateTransaction
- getNetwork
- getMirrorNetwork
- signTransaction
- getAccountBalance
- getAccountInfo
- getAccountRecords

**Related issue(s)**:


**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested - added unit tests
