### PR TITLE
Simplify method in DAppSigner

### DIFF
--- a/src/examples/typescript/dapp/index.html
+++ b/src/examples/typescript/dapp/index.html
@@ -293,6 +293,77 @@
           <button type="submit">Submit to wallet</button>
         </form>
       </section>
+      <hr />
+      <h2>Signer with Transactions:</h2>
+      <section>
+        <form id="signer_hedera_executeTransaction" class="toggle">
+          <fieldset>
+            <legend>2.(Signer) hedera_executeTransaction</legend>
+            <p>These fields can be constructed by using the `hedera_signTransaction` method</p>
+            <label
+              >Signer Account Id:
+              <input name="signer-execute" required />
+            </label>
+            <label
+              >Base64 Encoded TransactionBody protobuf:
+              <input name="signer-execute-transaction-body" required />
+            </label>
+            <label
+              >Base64 Encoded SignatureMap protobuf:
+              <input name="signer-execute-transaction-signature-map" required />
+            </label>
+          </fieldset>
+          <button type="submit">Submit to wallet</button>
+        </form>
+      </section>
+      <section>
+        <form id="signer_hedera_signMessage" class="toggle">
+          <fieldset>
+            <legend>3.(Signer) hedera_signMessage</legend>
+            <label
+              >Message:
+              <input name="signer-sign-message" required />
+            </label>
+            <label
+              >Signer Account Id:
+              <input name="signer-message-from" required />
+            </label>
+            <label
+              >Hedera Testnet Public Key:
+              <input name="signer-public-key" required />
+            </label>
+            <p>The public key for the account is used to verify the signed message</p>
+          </fieldset>
+          <button type="submit">Submit to wallet</button>
+          <p id="signer-sign-message-result"></p>
+        </form>
+      </section>
+      <section>
+        <form id="signer_hedera_signAndExecuteTransaction" class="toggle">
+          <fieldset>
+            <legend>5.(Signer) hedera_signAndExecuteTransaction</legend>
+            <label
+              >Transaction type:
+              <select name="signer-sign-send-transaction-type">
+                <option value="signer-hbar-transfer">Hbar Transfer</option>
+              </select>
+            </label>
+            <label
+              >Send to address:
+              <input name="signer-sign-send-to" required />
+            </label>
+            <label
+              >Send from address:
+              <input name="signer-sign-send-from" required />
+            </label>
+            <label
+              >Amount in Hbar:
+              <input name="signer-sign-send-amount" required />
+            </label>
+          </fieldset>
+          <button type="submit">Submit to wallet</button>
+        </form>
+      </section>
 
       <hr />
       <h2>Error handling:</h2>

--- a/src/lib/dapp/DAppSigner.ts
+++ b/src/lib/dapp/DAppSigner.ts
@@ -44,9 +44,11 @@ import { proto } from '@hashgraph/proto'
 import type { ISignClient } from '@walletconnect/types'
 
 import {
+  ExecuteTransactionResult,
   HederaJsonRpcMethod,
   SignAndExecuteQueryResult,
   SignAndExecuteTransactionResult,
+  SignMessageResult,
   SignTransactionResult,
   Uint8ArrayToBase64String,
   base64StringToSignatureMap,
@@ -291,5 +293,48 @@ export class DAppSigner implements Signer {
           2,
         ),
     )
+  }
+
+  /*
+   *  Extra methods
+   */
+
+  async executeTransaction<T extends Transaction>(transaction: T) {
+    return this.request<ExecuteTransactionResult['result']>({
+      method: HederaJsonRpcMethod.ExecuteTransaction,
+      params: { transactionList: transactionToBase64String(transaction) },
+    })
+  }
+
+  async signMessage(message: string) {
+    const params = {
+      signerAccountId: this._signerAccountId,
+      message,
+    }
+    return this.request<SignMessageResult['result']>({
+      method: HederaJsonRpcMethod.SignMessage,
+      params,
+    })
+  }
+
+  async signAndExecuteQuery(query: string) {
+    const params = {
+      signerAccountId: this._signerAccountId,
+      query,
+    }
+    return this.request<SignAndExecuteQueryResult['result']>({
+      method: HederaJsonRpcMethod.SignAndExecuteQuery,
+      params,
+    })
+  }
+
+  async signAndExecuteTransaction<T extends Transaction>(transaction: T) {
+    return this.request<SignAndExecuteTransactionResult['result']>({
+      method: HederaJsonRpcMethod.SignAndExecuteTransaction,
+      params: {
+        signerAccountId: this._signerAccountId,
+        transactionList: transactionToBase64String(transaction),
+      },
+    })
   }
 }


### PR DESCRIPTION
Enhance DAppSigner by adding methods that streamline communication for dapps, requiring just a Transaction or basic parameters and eliminating the need for developers to construct complex objects.

**Description**:
Add methods to facilitate the integration for dApps developers.  
 * support Transaction at signTransaction, signAndExecuteTransaction and executeTransaction methods
 * support only a string to sign messages
 * support only a string to sign and execute a query

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
This pull request is part of PR #76, which will be permanently deleted once all topics are split.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
