### PR TITLE
force exit so that tests complete in github actions

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -23,6 +23,7 @@ import type { Config } from 'jest'
 const config: Config = {
   preset: 'ts-jest/presets/js-with-ts',
   detectOpenHandles: true,
+  forceExit: true,
   fakeTimers: {
     enableGlobally: true,
   },


### PR DESCRIPTION
**Description**:
<!--
Open connections were stopping the tests from closing. Fixes #141

-->

**Related issue(s)**:

This should also allow tests to pass here https://github.com/hashgraph/hedera-wallet-connect/pull/116
as well as run tests that are currently skipped for this reason - https://github.com/hashgraph/hedera-wallet-connect/blob/main/jest.config.ts

**Notes for reviewer**:
- clone the repo
- run `npm run test`

The tests should now exit after successfully completing.>
**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
