### PR TITLE
Update DAppSigner.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hashgraph/hedera-wallet-connect",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hashgraph/hedera-wallet-connect",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hashgraph/sdk": "^2.40.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashgraph/hedera-wallet-connect",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A library to facilitate integrating Hedera with WalletConnect",
   "repository": {
     "type": "git",

--- a/src/lib/dapp/DAppSigner.ts
+++ b/src/lib/dapp/DAppSigner.ts
@@ -173,6 +173,14 @@ export class DAppSigner implements Signer {
       .setTransactionId(TransactionId.generate(this.getAccountId()))
   }
 
+  /**
+   * Prepares a transaction object for signing using a single node account id.
+   * If the transaction object does not already have a node account id,
+   * generate a random node account id using the Hedera SDK client
+   *
+   * @param transaction - Any instance of a class that extends `Transaction`
+   * @returns transaction - `Transaction` object with signature
+   */
   async signTransaction<T extends Transaction>(transaction: T): Promise<T> {
     let nodeAccountId: AccountId
     if (!transaction.nodeAccountIds || transaction.nodeAccountIds.length === 0)

--- a/src/lib/dapp/DAppSigner.ts
+++ b/src/lib/dapp/DAppSigner.ts
@@ -174,9 +174,13 @@ export class DAppSigner implements Signer {
   }
 
   async signTransaction<T extends Transaction>(transaction: T): Promise<T> {
+    let nodeAccountId: AccountId
+    if (!transaction.nodeAccountIds || transaction.nodeAccountIds.length === 0)
+      nodeAccountId = this._getRandomNodes(1)[0]
+    else nodeAccountId = transaction.nodeAccountIds[0]
     const transactionBody: proto.TransactionBody = transactionToTransactionBody(
       transaction,
-      transaction.nodeAccountIds[0],
+      nodeAccountId,
     )
     const transactionBodyBase64 = transactionBodyToBase64String(transactionBody)
 

--- a/src/lib/dapp/DAppSigner.ts
+++ b/src/lib/dapp/DAppSigner.ts
@@ -176,7 +176,7 @@ export class DAppSigner implements Signer {
   async signTransaction<T extends Transaction>(transaction: T): Promise<T> {
     const transactionBody: proto.TransactionBody = transactionToTransactionBody(
       transaction,
-      this._getRandomNodes(1)[0],
+      transaction.nodeAccountIds[0],
     )
     const transactionBodyBase64 = transactionBodyToBase64String(transactionBody)
 


### PR DESCRIPTION
When working with HSuite they were encountering issues with signing transactions, this is the change we applied to hashconnect in order to fix the issue. When signing a transaction multiple times (multisig), you want to preserve the node id.

May resolve this: https://github.com/hashgraph/hedera-wallet-connect/issues/124