### PR TITLE
chore: Added hgraph-io-hedera to CODEOWNERS and updated to include devops-ci

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default code owners for entire repository
-*   @hashgraph/developer-advocates
+*   @hashgraph/developer-advocates @hashgraph/hgraph-io-hedera
 
 #########################
 #####  Core Files  ######
@@ -8,28 +8,28 @@
 # NOTE: Must be placed last to ensure enforcement over all other rules
 
 # Protection Rules for Github Configuration Files and Actions Workflows
-/.github/                                       @hashgraph/release-engineering @hashgraph/release-engineering-managers
-/.github/workflows/                             @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/developer-advocates
+/.github/                                       @hashgraph/devops-ci @hashgraph/release-engineering-managers
+/.github/workflows/                             @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/developer-advocates @hashgraph/hgraph-io-hedera
 
 # NPM and typescript protections
-**/.npmignore                                   @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/developer-advocates
-**/package.json                                 @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/developer-advocates
-**/package-lock.json                            @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/developer-advocates
-**/tsconfig.json                                @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/developer-advocates
-**/typedoc.json                                 @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/developer-advocates
-**/jest.config.ts                               @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/developer-advocates
+**/.npmignore                                   @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/developer-advocates @hashgraph/hgraph-io-hedera
+**/package.json                                 @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/developer-advocates @hashgraph/hgraph-io-hedera
+**/package-lock.json                            @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/developer-advocates @hashgraph/hgraph-io-hedera
+**/tsconfig.json                                @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/developer-advocates @hashgraph/hgraph-io-hedera
+**/typedoc.json                                 @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/developer-advocates @hashgraph/hgraph-io-hedera
+**/jest.config.ts                               @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/developer-advocates @hashgraph/hgraph-io-hedera
 
 # Rules for prettier
-**/.prettierignore                              @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/developer-advocates
-**/.prettierrc                                  @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/developer-advocates
+**/.prettierignore                              @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/developer-advocates @hashgraph/hgraph-io-hedera
+**/.prettierrc                                  @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/developer-advocates @hashgraph/hgraph-io-hedera
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
-/CODEOWNERS                                     @hashgraph/release-engineering @hashgraph/release-engineering-managers
+/CODEOWNERS                                     @hashgraph/devops-ci @hashgraph/release-engineering-managers
 
 # Protect the repository root files
-/README.md                                      @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/developer-advocates
-**/LICENSE                                      @hashgraph/release-engineering @hashgraph/release-engineering-managers
+/README.md                                      @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/developer-advocates @hashgraph/hgraph-io-hedera
+**/LICENSE                                      @hashgraph/release-engineering-managers
 
 # Git Ignore definitions
-**/.gitignore                                   @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/developer-advocates
-**/.gitignore.*                                 @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/developer-advocates
+**/.gitignore                                   @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/developer-advocates @hashgraph/hgraph-io-hedera
+**/.gitignore.*                                 @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/developer-advocates @hashgraph/hgraph-io-hedera


### PR DESCRIPTION
**Description**:

Adds hgraph-io-hedera and devops-ci to CODEOWNERS and remove release-engineering from a slew of CODEOWNERS items

**Related issue(s)**:

Fixes #173

**Notes for reviewer**:

This is in reference to https://swirldslabs.freshdesk.com/a/tickets/3107