### PR TITLE
rename the github action workflow to accurately describe what the wor…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
       - published
 jobs:
   publish:
-    name: docker
+    name: publish
     runs-on: [self-hosted, Linux, medium, ephemeral]
 
     permissions:


### PR DESCRIPTION
simple change to rename the github action job to be what the action actually does. Below is a screenshot where it says `docker`. The github action was based off of an action in another repository that built docker images, however this library does not build a docker container.

<img width="1509" alt="Screenshot 2024-07-29 at 11 38 58 AM" src="https://github.com/user-attachments/assets/54afff01-9c1b-4741-bcf2-055a12af9b98">
