### PR TITLE
add deprecation warning for a method that uses and outdated WalletCon…

### DIFF
--- a/src/lib/dapp/index.ts
+++ b/src/lib/dapp/index.ts
@@ -178,6 +178,7 @@ export class DAppConnector {
 
   /**
    * Initiates the WalletConnect connection flow using a QR code.
+   * @deprecated Use `openModal` instead.
    * @param pairingTopic - The pairing topic for the connection (optional).
    * @returns A Promise that resolves when the connection process is complete.
    */


### PR DESCRIPTION
`src/lib/dapp/index.ts` uses the deprecated `@walletconnect/qrcode-modal` as 1 way to connect via wallet connect. This library is no longer supported and there is an alternate method in the dAppConnector to initiate a WalletConnect connection - `openModal`

This adds a deprecated warning to signify that the old method is deprecated and the newer method should be used.