### PR TITLE
fix session error that was caused by disconnection on the wallet side

### DIFF
--- a/src/lib/dapp/index.ts
+++ b/src/lib/dapp/index.ts
@@ -152,16 +152,13 @@ export class DAppConnector {
       this.walletConnectClient.on('session_delete', (pairing) => {
         console.log(pairing)
         this.signers = this.signers.filter((signer) => signer.topic !== pairing.topic)
-        this.disconnect(pairing.topic)
         // Session was deleted -> reset the dapp state, clean up from user session, etc.
         console.log('Dapp: Session deleted by wallet!')
       })
 
       this.walletConnectClient.core.pairing.events.on('pairing_delete', (pairing) => {
-        // Session was deleted
         console.log(pairing)
         this.signers = this.signers.filter((signer) => signer.topic !== pairing.topic)
-        this.disconnect(pairing.topic)
         console.log(`Dapp: Pairing deleted by wallet!`)
         // clean up after the pairing for `topic` was deleted.
       })


### PR DESCRIPTION
**Description**:

This PR fixes a DApp client session error that occurred when disconnecting the DApp by the wallet.

**Related issue(s)**:
https://github.com/hashgraph/hedera-wallet-connect/issues/281

**Notes for reviewer**:
The error occurred because the dApp client was trying to delete a session that had already been deleted in these event handlers: `session_delete` and `pairing_delete`.
