### PR TITLE
ci: creates a pipeline for canary npm releases for testing

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -1,0 +1,43 @@
+name: Publish Canary
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  publish-canary:
+    name: Publish Canary
+    runs-on: wallet-tools-linux-medium
+    permissions:
+      contents: read
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup NodeJS Environment
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: 18.x
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Create .npmrc
+        run: |
+          touch .npmrc
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> .npmrc
+
+      - name: Set prerelease version
+        run: |
+          npm version prerelease --preid="canary.$(git rev-parse --short HEAD)" --no-git-tag-version
+
+      - name: Publish
+        run: npm publish --tag canary --public
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
**Description**:
This PR adds a new pipeline to create canary releases on NPM every time a PR is made to the `main` branch. Canary builds help us iterate quickly by allowing early adopters and team members to test changes before they hit production.

Note, this will NOT work on forks. 

**Notes for reviewer**:
This PR can be tested by creating a branch like this one and issuing a PR to `main`, for example this PR triggered the pipeline here: https://github.com/hashgraph/hedera-wallet-connect/actions/runs/11690325054

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
