### PR TITLE
ci: skip canary on fork

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   publish-canary:
     name: Publish Canary
+    if: github.event.pull_request.head.repo.fork == false
     runs-on: wallet-tools-linux-medium
     permissions:
       contents: read


### PR DESCRIPTION
**Description**:
Canary was running for PRs that were from forked repos, causing them to fail because they cannot access the NPM secrets. This PR skips canary publish if it is not made from the main origin. 

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
