### PR TITLE
fix: adjust signTransaction parameters

### DIFF
--- a/demos/react-dapp/src/App.tsx
+++ b/demos/react-dapp/src/App.tsx
@@ -14,7 +14,6 @@ import {
   TopicCreateTransaction,
 } from '@hashgraph/sdk'
 import { SessionTypes, SignClientTypes } from '@walletconnect/types'
-import { proto } from '@hashgraph/proto'
 import * as nacl from 'tweetnacl'
 
 import {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hashgraph/hedera-wallet-connect",
-  "version": "1.3.7",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hashgraph/hedera-wallet-connect",
-      "version": "1.3.7",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@hashgraph/hedera-wallet-connect": "^1.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "react-dom": "^18.2.0",
         "rimraf": "^5.0.5",
         "ts-node": "^10.9.2",
+        "tweetnacl": "^1.0.3",
         "typedoc": "^0.26.3",
         "typedoc-theme-hierarchy": "^4.1.2",
         "typescript": "^5.2.2"
@@ -10132,9 +10133,7 @@
     "node_modules/tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "license": "Unlicense",
-      "peer": true
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
@@ -10236,11 +10235,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "husky": "^9.0.6",
     "jest": "^29.7.0",
     "lint-staged": "^15.1.0",
-    "long": "^5.2.3",
     "lokijs": "^1.5.12",
+    "long": "^5.2.3",
     "nodemon": "^3.0.3",
     "prettier": "^3.2.4",
     "react": "^18.2.0",
@@ -42,7 +42,8 @@
     "ts-node": "^10.9.2",
     "typedoc": "^0.26.3",
     "typedoc-theme-hierarchy": "^4.1.2",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "tweetnacl": "^1.0.3"
   },
   "scripts": {
     "build": "rimraf dist && tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashgraph/hedera-wallet-connect",
-  "version": "1.3.7",
+  "version": "1.4.0",
   "description": "A library to facilitate integrating Hedera with WalletConnect",
   "repository": {
     "type": "git",

--- a/src/lib/dapp/index.ts
+++ b/src/lib/dapp/index.ts
@@ -44,7 +44,6 @@ import {
   SignAndExecuteTransactionRequest,
   SignAndExecuteTransactionResult,
   SignTransactionParams,
-  SignTransactionRequest,
   SignTransactionResult,
   ExtensionData,
   extensionConnect,
@@ -613,26 +612,34 @@ export class DAppConnector {
    *
    * @param {SignTransactionParams} params - The parameters of type {@link SignTransactionParams | `SignTransactionParams`} required for `Transaction` signing.
    * @param {string} params.signerAccountId - a signer Hedera Account identifier in {@link https://hips.hedera.com/hip/hip-30 | HIP-30} (`<nework>:<shard>.<realm>.<num>`) form.
-   * @param {string[]} params.transaction - Array of Base64-encoded `Transaction`'s
+   * @param {Transaction} params.transaction - a built Transaction.
    * @returns Promise\<{@link SignTransactionResult}\>
    * @example
    * ```ts
-   * const transactionBodyObject = transactionToTransactionBody(transaction, AccountId.fromString('0.0.3'))
-   * const transactionBody = transactionBodyToBase64String(transactionBodyObject)
    *
    * const params = {
    *  signerAccountId: '0.0.12345',
-   *  transactionBody
+   *  transaction
    * }
    *
    * const result = await dAppConnector.signTransaction(params)
    * ```
    */
   public async signTransaction(params: SignTransactionParams) {
-    return await this.request<SignTransactionRequest, SignTransactionResult>({
-      method: HederaJsonRpcMethod.SignTransaction,
-      params,
-    })
+    const signerAccountId = params?.signerAccountId?.split(':')?.pop()
+    const accountSigner = this.signers.find(
+      (signer) => signer?.getAccountId()?.toString() === signerAccountId,
+    )
+
+    if (!accountSigner) {
+      throw new Error(`No signer found for account ${signerAccountId}`)
+    }
+
+    if (!params?.transaction) {
+      throw new Error('No transaction provided')
+    }
+
+    return await accountSigner.signTransaction(params.transaction)
   }
 
   private handleSessionEvent(

--- a/src/lib/shared/payloads.ts
+++ b/src/lib/shared/payloads.ts
@@ -20,7 +20,7 @@
 
 import { JsonRpcResult } from '@walletconnect/jsonrpc-types'
 import { EngineTypes } from '@walletconnect/types'
-import type { TransactionResponseJSON } from '@hashgraph/sdk'
+import type { Transaction, TransactionResponseJSON } from '@hashgraph/sdk'
 import { HederaJsonRpcMethod } from './methods'
 
 /**
@@ -152,7 +152,7 @@ export interface SignAndExecuteTransactionResponse extends EngineTypes.RespondPa
 // params
 export interface SignTransactionParams {
   signerAccountId: string
-  transactionBody: string
+  transaction: Transaction
 }
 
 //request

--- a/src/lib/shared/utils.ts
+++ b/src/lib/shared/utils.ts
@@ -107,7 +107,7 @@ export function transactionToTransactionBody<T extends Transaction>(
   return transaction._makeTransactionBody(nodeAccountId)
 }
 
-export function transactionBodyToBase64String(transactionBody: proto.ITransactionBody) {
+export function transactionBodyToBase64String(transactionBody: proto.ITransactionBody): string {
   return Uint8ArrayToBase64String(proto.TransactionBody.encode(transactionBody).finish())
 }
 
@@ -118,6 +118,21 @@ export function transactionBodyToBase64String(transactionBody: proto.ITransactio
 export function transactionListToBase64String(transactionList: proto.TransactionList) {
   const encoded = proto.TransactionList.encode(transactionList).finish()
   return Uint8ArrayToBase64String(encoded)
+}
+
+/**
+ * Extracts the first signature from a proto.SignatureMap object.
+ * @param signatureMap - a proto.SignatureMap object
+ * @returns `Uint8Array`
+ * */
+export const extractFirstSignature = (signatureMap: proto.ISignatureMap): Uint8Array => {
+  const firstPair = signatureMap?.sigPair?.[0]
+  const firstSignature = firstPair?.ed25519 || firstPair?.ECDSASecp256k1 || firstPair?.ECDSA_384
+
+  if (!firstSignature) {
+    throw new Error('No signatures found in response')
+  }
+  return firstSignature
 }
 
 /**


### PR DESCRIPTION
**Description**:

This PR simplifies the logic when `signTransaction` is called from the `dAppConnector`. Rather than process the call through `request`, it calls the `signTransaction` method already present on `DAppSigner`. This is important because, `signTransaction` on `DAppSigner` ensures the signature maps are properly returned while the previous method did not. 

To explore this further, I've added a new section in the react demo to verify the signature maps are valid, and unit tests that cover this. 

**Related issue(s)**:

Fixes #

https://github.com/hashgraph/hedera-wallet-connect/issues/330
https://github.com/hashgraph/hedera-wallet-connect/issues/124

**Notes for reviewer**:

Because this changes the parameters of `signTransaction`, this will be a breaking change.

 - You can test this by running `npm run dev:react-demo`
 - Scroll to the bottom and run the verify signatures button
 
![image](https://github.com/user-attachments/assets/1a44cfc4-7ab8-43f2-bb50-1c4da53050d9)

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
