### PR TITLE
ci: run publish step only on main branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,8 @@
 
 # Protection Rules for Github Configuration Files and Actions Workflows
 /.github/                                               @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers @hashgraph/hgraph-io-hedera
-/.github/workflows/                                     @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers @hashgraph/hgraph-io-hedera
+/.github/workflows/                                     @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers
+/.github/CODEOWNERS                                     @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers
 
 # NPM and typescript protections
 **/.npmignore                                           @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/developer-advocates @hashgraph/hgraph-io-hedera

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -39,6 +39,7 @@ jobs:
           npm version prerelease --preid="canary.$(git rev-parse --short HEAD)" --no-git-tag-version
 
       - name: Publish
+        if: ${{ github.ref == 'refs/heads/main' }}
         run: npm publish --tag canary --public
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -1,6 +1,6 @@
 name: Publish Canary
 on:
-  pull_request:
+  push:
     branches:
       - main
 
@@ -39,7 +39,6 @@ jobs:
           npm version prerelease --preid="canary.$(git rev-parse --short HEAD)" --no-git-tag-version
 
       - name: Publish
-        if: ${{ github.ref == 'refs/heads/main' }}
         run: npm publish --tag canary --public
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,6 @@ jobs:
             echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> .npmrc
 
       - name: Publish
-        if: ${{ github.ref == 'refs/heads/main' }}
         run: npm publish --public
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,7 @@ jobs:
             echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> .npmrc
 
       - name: Publish
+        if: ${{ github.ref == 'refs/heads/main' }}
         run: npm publish --public
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
**Description**:

Add a check to the `publish-canary.yml` workflow to only publish when on the mainline (`main`) branch. This will prevent publishing on a PR.

**Related issue(s)**:

Fixes #400 

