### PR TITLE
chore: bump version to 2.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hashgraph/hedera-wallet-connect",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hashgraph/hedera-wallet-connect",
-      "version": "2.0.6",
+      "version": "2.0.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "@hiero-ledger/proto": "^2.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashgraph/hedera-wallet-connect",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "A library to facilitate integrating Hedera with WalletConnect",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bumps package version from 2.0.6 to 2.0.7 in preparation for a new release
- Updates `package.json` and `package-lock.json`