### PR TITLE
fix: include EVM chains in WalletConnect session proposal for hedera namespace

### DIFF
--- a/src/reown/connectors/HederaConnector.ts
+++ b/src/reown/connectors/HederaConnector.ts
@@ -2,7 +2,7 @@ import type { SessionTypes } from '@walletconnect/types'
 import { CaipNetwork, ChainNamespace, ConstantsUtil } from '@reown/appkit-common'
 import { AdapterBlueprint, type ChainAdapterConnector } from '@reown/appkit-controllers'
 import { PresetsUtil } from '@reown/appkit-utils'
-import { createNamespaces } from '../utils'
+import { createNamespaces, HederaChainDefinition } from '../utils'
 
 type UniversalProvider = Parameters<AdapterBlueprint['setUniversalProvider']>[0]
 
@@ -31,6 +31,23 @@ export class HederaConnector implements ChainAdapterConnector {
 
   async connectWalletConnect() {
     const namespaces = createNamespaces(this.caipNetworks)
+
+    // Include corresponding EVM chains so EVM-based wallets (e.g. Safe multisig)
+    // can match their network in the session proposal
+    if (this.chain === ('hedera' as ChainNamespace)) {
+      const nativeToEvm: Record<string, CaipNetwork> = {
+        mainnet: HederaChainDefinition.EVM.Mainnet,
+        testnet: HederaChainDefinition.EVM.Testnet,
+      }
+      const evmChains = this.caipNetworks
+        .map((n) => nativeToEvm[n.id as string])
+        .filter(Boolean)
+      if (evmChains.length > 0) {
+        const evmNamespaces = createNamespaces(evmChains)
+        Object.assign(namespaces, evmNamespaces)
+      }
+    }
+
     const connectParams = { optionalNamespaces: namespaces }
 
     await this.provider.connect(connectParams)

--- a/test/reown/connectors/HederaConnector.test.ts
+++ b/test/reown/connectors/HederaConnector.test.ts
@@ -19,7 +19,7 @@
  */
 
 import { CaipNetwork } from '@reown/appkit-common'
-import { createNamespaces, HederaChainDefinition } from '../../../src'
+import { HederaChainDefinition } from '../../../src'
 import { HederaConnector } from '../../../src/reown/connectors'
 
 const mockProvider = {
@@ -53,11 +53,13 @@ describe('HederaConnector', () => {
   })
 
   describe('connectWalletConnect', () => {
-    it('should connect with correct namespaces', async () => {
+    it('should connect with correct namespaces including EVM chains', async () => {
       await connector.connectWalletConnect()
-      expect(mockProvider.connect).toHaveBeenCalledWith({
-        optionalNamespaces: createNamespaces(testNetworks),
-      })
+      const callArgs = mockProvider.connect.mock.calls[0][0]
+      expect(callArgs.optionalNamespaces.hedera).toBeDefined()
+      expect(callArgs.optionalNamespaces.eip155).toBeDefined()
+      expect(callArgs.optionalNamespaces.hedera.chains).toEqual(['hedera:mainnet'])
+      expect(callArgs.optionalNamespaces.eip155.chains).toEqual(['eip155:295'])
     })
 
     it('should always call connect with optionalNamespaces', async () => {
@@ -67,23 +69,22 @@ describe('HederaConnector', () => {
 
       const result = await connector.connectWalletConnect()
 
-      expect(mockProvider.connect).toHaveBeenCalledWith({
-        optionalNamespaces: {
-          hedera: {
-            chains: ['hedera:mainnet'],
-            events: ['accountsChanged', 'chainChanged'],
-            methods: [
-              'hedera_getNodeAddresses',
-              'hedera_executeTransaction',
-              'hedera_signMessage',
-              'hedera_signAndExecuteQuery',
-              'hedera_signAndExecuteTransaction',
-              'hedera_signTransaction',
-            ],
-            rpcMap: { mainnet: 'https://mainnet.hashio.io/api' },
-          },
-        },
+      const callArgs = mockProvider.connect.mock.calls[0][0]
+      expect(callArgs.optionalNamespaces.hedera).toEqual({
+        chains: ['hedera:mainnet'],
+        events: ['accountsChanged', 'chainChanged'],
+        methods: [
+          'hedera_getNodeAddresses',
+          'hedera_executeTransaction',
+          'hedera_signMessage',
+          'hedera_signAndExecuteQuery',
+          'hedera_signAndExecuteTransaction',
+          'hedera_signTransaction',
+        ],
+        rpcMap: { mainnet: 'https://mainnet.hashio.io/api' },
       })
+      expect(callArgs.optionalNamespaces.eip155).toBeDefined()
+      expect(callArgs.optionalNamespaces.eip155.chains).toEqual(['eip155:295'])
       expect(result).toEqual({ clientId: 'id', session: mockProvider.session })
     })
   })


### PR DESCRIPTION
## Summary
- EVM-based wallets like Safe multisig run on Hedera's EVM layer (`eip155:295`/`eip155:296`) and need to find their chain in the WalletConnect session proposal
- When the adapter uses the `hedera` namespace, only `hedera:mainnet`/`hedera:testnet` were advertised, causing Safe to reject the connection with "unsupported network"
- This adds the corresponding EVM chains as optional namespaces so both native Hedera and EVM wallets can connect

## What changed
- `src/reown/connectors/HederaConnector.ts` - when the connector's namespace is `hedera`, the corresponding EVM chains are automatically included as optional namespaces in the WalletConnect session proposal

## Test plan
- [x] Run `npm run build` - no TypeScript errors
- [x] Connect a Hedera dApp (hedera namespace) to Safe multisig via WalletConnect
- [x] Verify the session proposal includes both `hedera:mainnet` and `eip155:295`
- [x] Verify native Hedera wallets (e.g. HashPack) still connect normally
