### PR TITLE
fix(HederaAdapter): route HashPack through WalletConnect

### DIFF
--- a/src/reown/adapter.ts
+++ b/src/reown/adapter.ts
@@ -53,6 +53,28 @@ type GetEnsAddressParams = {
 type GetEnsAddressResult = { address: string | false }
 type GetProfileResult = { profileImage: string; profileName: string }
 
+// HashPack's extension announces an EVM-only EIP-1193 provider via EIP-6963.
+// When a dApp pairs HederaAdapter with an EVM adapter, Reown registers that
+// announcement as an "installed" tile, so clicking it connects via
+// eth_requestAccounts and leaves the Hedera WC session undefined. Swallowing
+// the announcement keeps the wallet visible via Reown's explorer listing and
+// forces clicks through the WalletConnect flow.
+// https://github.com/hashgraph/hedera-wallet-connect/issues/670
+let hashpackFilterTarget: EventTarget | null = null
+function installHashpackEip6963Filter(): void {
+  const target: EventTarget | null = typeof window !== 'undefined' ? window : null
+  if (!target || hashpackFilterTarget === target) return
+  target.addEventListener(
+    'eip6963:announceProvider',
+    (event) => {
+      const rdns = (event as CustomEvent<{ info?: { rdns?: string } }>).detail?.info?.rdns
+      if (rdns === 'app.hashpack') event.stopImmediatePropagation()
+    },
+    { capture: true },
+  )
+  hashpackFilterTarget = target
+}
+
 export class HederaAdapter extends AdapterBlueprint {
   private static INJECTED_DISCONNECT_KEY = '@hwc/injected-disconnected'
   private logger = createLogger('HederaAdapter')
@@ -79,6 +101,8 @@ export class HederaAdapter extends AdapterBlueprint {
     super({
       ...params,
     })
+
+    if (params.namespace === hederaNamespace) installHashpackEip6963Filter()
 
     this.getCaipNetworks = (namespace?: ChainNamespace): CaipNetwork[] => {
       const targetNamespace = namespace || this.namespace

--- a/test/reown/adapter.hederaNativeWalletFilter.test.ts
+++ b/test/reown/adapter.hederaNativeWalletFilter.test.ts
@@ -1,0 +1,71 @@
+import { HederaAdapter, hederaNamespace } from '../../src'
+
+const EVENT = 'eip6963:announceProvider'
+
+describe('HederaAdapter filters HashPack EIP-6963 announcement', () => {
+  const originalWindow = (globalThis as any).window
+  let target: EventTarget
+
+  const announce = (rdns: string | undefined) =>
+    target.dispatchEvent(
+      new CustomEvent(EVENT, {
+        detail: rdns === undefined ? {} : { info: { rdns } },
+      }),
+    )
+
+  beforeEach(() => {
+    target = new EventTarget()
+    ;(globalThis as any).window = target
+  })
+
+  afterEach(() => {
+    if (originalWindow === undefined) {
+      delete (globalThis as any).window
+    } else {
+      ;(globalThis as any).window = originalWindow
+    }
+  })
+
+  it('filters HashPack when namespace is hedera and passes others through', () => {
+    new HederaAdapter({ namespace: hederaNamespace })
+
+    const downstream = jest.fn()
+    target.addEventListener(EVENT, downstream)
+
+    announce('app.hashpack')
+    announce('io.metamask')
+
+    expect(downstream).toHaveBeenCalledTimes(1)
+    expect(
+      (downstream.mock.calls[0][0] as CustomEvent).detail.info.rdns,
+    ).toBe('io.metamask')
+  })
+
+  it('does not install the filter when namespace is eip155', () => {
+    new HederaAdapter({ namespace: 'eip155' })
+
+    const downstream = jest.fn()
+    target.addEventListener(EVENT, downstream)
+
+    announce('app.hashpack')
+
+    expect(downstream).toHaveBeenCalledTimes(1)
+  })
+
+  it('is idempotent across multiple adapter instances', () => {
+    new HederaAdapter({ namespace: hederaNamespace })
+    new HederaAdapter({ namespace: hederaNamespace })
+
+    const downstream = jest.fn()
+    target.addEventListener(EVENT, downstream)
+
+    announce('app.hashpack')
+
+    expect(downstream).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op when window is unavailable', () => {
+    delete (globalThis as any).window
+    expect(() => new HederaAdapter({ namespace: hederaNamespace })).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #670.

When an AppKit is configured with both `HederaAdapter` (hedera namespace) and an EVM adapter such as `WagmiAdapter`, clicking the "HashPack" tile in the Reown modal connects through the injected EIP-1193 provider (EIP-6963 announce) and returns an EVM address. The Hedera `UniversalProvider`'s session stays `undefined`, which breaks any flow that depends on native Hedera signing (e.g. stablecoin multisig). The QR / deep-link path already works.

Root cause: HashPack's extension (rdns `app.hashpack`) announces an EVM-only provider via EIP-6963, and Reown's wallet discovery registers it as an "installed" tile. `excludeWalletIds` hides the entry entirely and `customWallets` pairings bypass the connector that would sync AppKit state, so neither is a viable fix.

## Fix

`HederaAdapter` now installs an idempotent capture-phase listener on `window.eip6963:announceProvider` that calls `stopImmediatePropagation()` for `app.hashpack`. The wallet remains visible in the modal via Reown's explorer listing; clicking it pairs through the `HederaConnector` and populates `hederaProvider.session`.

- Installs automatically when `HederaAdapter` is constructed with `namespace: 'hedera'`. Pure-EVM dApps are unaffected.
- SSR-safe (no-op when `window` is unavailable).
- Idempotent across multiple adapter instances (tracked by install target).

## Test plan

- [x] `npm test` - full suite passes (490 / 2 skipped / 0 failing; 4 new tests)
- [x] Manual: dual-adapter AppKit (HederaAdapter + WagmiAdapter), HashPack extension installed
  - Before fix: HashPack tile shows INSTALLED, clicking it connects as `eip155` with a `0x…` address and `hederaProvider.session === undefined`
  - After fix: HashPack tile has no INSTALLED badge, clicking it opens the WC QR; after pairing, `address` is `0.0.x`, `chainNamespace` is `hedera`, and `hederaProvider.session.topic` is populated
- [ ] Reviewer should verify pure-EVM (WagmiAdapter-only) dApps are unaffected - HashPack should still show INSTALLED and connect via injected EIP-1193 there (no `HederaAdapter` means no filter install)

